### PR TITLE
BUGFIX: Correct fusion context assignment and fix psr2 errors

### DIFF
--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/Factory/FieldContextFactory.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/Factory/FieldContextFactory.php
@@ -23,13 +23,13 @@ use PackageFactory\AtomicFusion\Forms\Domain\Context\FieldContext;
 class FieldContextFactory
 {
     /**
-	 * Create a field context
-	 *
-	 * @param FormRuntimeInterface $formRuntime
-	 * @param string $fieldName
-	 * @param string $propertyPath
-	 * @return FieldContext
-	 */
+     * Create a field context
+     *
+     * @param FormRuntimeInterface $formRuntime
+     * @param string $fieldName
+     * @param string $propertyPath
+     * @return FieldContext
+     */
     public function createFieldContext(FormRuntimeInterface $formRuntime, $fieldName, $propertyPath = '')
     {
         return new FieldContext($formRuntime, $fieldName, $propertyPath);

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/Factory/FormContextFactory.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/Factory/FormContextFactory.php
@@ -23,11 +23,11 @@ use PackageFactory\AtomicFusion\Forms\Domain\Context\FormContext;
 class FormContextFactory
 {
     /**
-	 * Create a form context
-	 *
-	 * @param FormRuntimeInterface $formRuntime
-	 * @return FormContext
-	 */
+     * Create a form context
+     *
+     * @param FormRuntimeInterface $formRuntime
+     * @return FormContext
+     */
     public function createFormContext(FormRuntimeInterface $formRuntime)
     {
         return new FormContext($formRuntime);

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/Factory/PageContextFactory.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/Factory/PageContextFactory.php
@@ -23,12 +23,12 @@ use PackageFactory\AtomicFusion\Forms\Domain\Context\PageContext;
 class PageContextFactory
 {
     /**
-	 * Create a page context
-	 *
-	 * @param FormRuntimeInterface $formRuntime
-	 * @param string $pageName
-	 * @return PageContext
-	 */
+     * Create a page context
+     *
+     * @param FormRuntimeInterface $formRuntime
+     * @param string $pageName
+     * @return PageContext
+     */
     public function createPageContext(FormRuntimeInterface $formRuntime, $pageName)
     {
         return new PageContext($formRuntime, $pageName);

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/FieldContext.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/FieldContext.php
@@ -21,62 +21,62 @@ use PackageFactory\AtomicFusion\Forms\Domain\Service\Runtime\FormRuntimeInterfac
  */
 class FieldContext implements ProtectedContextAwareInterface
 {
-	/**
-	 * @var FormRuntimeInterface
-	 */
-	protected $formRuntime;
+    /**
+     * @var FormRuntimeInterface
+     */
+    protected $formRuntime;
 
-	/**
-	 * @var string
-	 */
-	protected $fieldName;
+    /**
+     * @var string
+     */
+    protected $fieldName;
 
-	/**
-	 * @var string
-	 */
-	protected $propertyPath;
+    /**
+     * @var string
+     */
+    protected $propertyPath;
 
-	/**
-	 * Constructor
-	 *
-	 * @param FormRuntimeInterface $formRuntime
-	 * @param string $fieldName
-	 * @param string $propertyPath
-	 */
-	public function __construct(FormRuntimeInterface $formRuntime, $fieldName, $propertyPath = '')
-	{
-		$this->formRuntime = $formRuntime;
-		$this->fieldName = $fieldName;
-		$this->propertyPath = $propertyPath;
-	}
+    /**
+     * Constructor
+     *
+     * @param FormRuntimeInterface $formRuntime
+     * @param string $fieldName
+     * @param string $propertyPath
+     */
+    public function __construct(FormRuntimeInterface $formRuntime, $fieldName, $propertyPath = '')
+    {
+        $this->formRuntime = $formRuntime;
+        $this->fieldName = $fieldName;
+        $this->propertyPath = $propertyPath;
+    }
 
-	/**
-	 * Get the field label
-	 *
-	 * @return string
-	 */
-	public function getLabel()
-	{
-		return $this->formRuntime->getFormDefinition()->getFieldDefinition($this->fieldName)->getLabel();
-	}
+    /**
+     * Get the field label
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->formRuntime->getFormDefinition()->getFieldDefinition($this->fieldName)->getLabel();
+    }
 
-	/**
-	 * Get the field name
-	 *
-	 * @return string
-	 */
-	public function getName()
-	{
-		$name = $this->formRuntime->getFormDefinition()->getFieldDefinition($this->fieldName)->getName();
-		$name = sprintf('[%s]', $name);
+    /**
+     * Get the field name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        $name = $this->formRuntime->getFormDefinition()->getFieldDefinition($this->fieldName)->getName();
+        $name = sprintf('[%s]', $name);
 
-		if ($this->propertyPath !== '') {
-			$propertyPathParts = explode('.', $this->propertyPath);
-			$name .= '[' . implode('][', $propertyPathParts) . ']';
-		}
+        if ($this->propertyPath !== '') {
+            $propertyPathParts = explode('.', $this->propertyPath);
+            $name .= '[' . implode('][', $propertyPathParts) . ']';
+        }
 
-		return $this->formRuntime->getRequest()->getArgumentNamespace() . $name;
-	}
+        return $this->formRuntime->getRequest()->getArgumentNamespace() . $name;
+    }
 
     /**
      * Get the argument
@@ -85,10 +85,10 @@ class FieldContext implements ProtectedContextAwareInterface
      */
     public function getArgument()
     {
-		$finalPropertyPath = $this->fieldName;
-		if ($this->propertyPath !== '') {
-			$finalPropertyPath .= '.' . $this->propertyPath;
-		}
+        $finalPropertyPath = $this->fieldName;
+        if ($this->propertyPath !== '') {
+            $finalPropertyPath .= '.' . $this->propertyPath;
+        }
 
         return $this->formRuntime->getFormState()->getArgument($finalPropertyPath);
     }
@@ -100,10 +100,10 @@ class FieldContext implements ProtectedContextAwareInterface
      */
     public function getValue()
     {
-		$finalPropertyPath = $this->fieldName;
-		if ($this->propertyPath !== '') {
-			$finalPropertyPath .= '.' . $this->propertyPath;
-		}
+        $finalPropertyPath = $this->fieldName;
+        if ($this->propertyPath !== '') {
+            $finalPropertyPath .= '.' . $this->propertyPath;
+        }
 
         return $this->formRuntime->getFormState()->getValue($finalPropertyPath);
     }
@@ -115,10 +115,10 @@ class FieldContext implements ProtectedContextAwareInterface
      */
     public function getValidationResult()
     {
-		$finalPropertyPath = $this->fieldName;
-		if ($this->propertyPath !== '') {
-			$finalPropertyPath .= '.' . $this->propertyPath;
-		}
+        $finalPropertyPath = $this->fieldName;
+        if ($this->propertyPath !== '') {
+            $finalPropertyPath .= '.' . $this->propertyPath;
+        }
 
         return $this->formRuntime->getFormState()->getValidationResult()->forProperty($finalPropertyPath);
     }
@@ -133,12 +133,12 @@ class FieldContext implements ProtectedContextAwareInterface
         return $this->getValidationResult()->hasErrors();
     }
 
-	/**
+    /**
      * @param string $methodName
      * @return boolean
      */
     public function allowsCallOfMethod($methodName)
     {
-		return true;
+        return true;
     }
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/FormContext.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/FormContext.php
@@ -20,10 +20,10 @@ use PackageFactory\AtomicFusion\Forms\Domain\Service\Runtime\FormRuntimeInterfac
  */
 class FormContext implements ProtectedContextAwareInterface
 {
-	/**
-	 * @var FormRuntimeInterface
-	 */
-	protected $formRuntime;
+    /**
+     * @var FormRuntimeInterface
+     */
+    protected $formRuntime;
 
     /**
      * @Flow\Inject
@@ -37,94 +37,94 @@ class FormContext implements ProtectedContextAwareInterface
      */
     protected $pageContextFactory;
 
-	/**
-	 * @var array
-	 */
-	protected $requestedFieldNames = [];
+    /**
+     * @var array
+     */
+    protected $requestedFieldNames = [];
 
-	/**
-	 * Constructor
-	 *
-	 * @param FormRuntimeInterface $formRuntime
-	 */
-	public function __construct(FormRuntimeInterface $formRuntime)
-	{
-		$this->formRuntime = $formRuntime;
-	}
+    /**
+     * Constructor
+     *
+     * @param FormRuntimeInterface $formRuntime
+     */
+    public function __construct(FormRuntimeInterface $formRuntime)
+    {
+        $this->formRuntime = $formRuntime;
+    }
 
-	/**
-	 * Get the form label
-	 *
-	 * @return string
-	 */
-	public function getLabel()
-	{
-		return $this->formRuntime->getFormDefinition()->getLabel();
-	}
+    /**
+     * Get the form label
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->formRuntime->getFormDefinition()->getLabel();
+    }
 
-	/**
-	 * Get the form name
-	 *
-	 * @return string
-	 */
-	public function getName()
-	{
-		return $this->formRuntime->getFormDefinition()->getName();
-	}
+    /**
+     * Get the form name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->formRuntime->getFormDefinition()->getName();
+    }
 
-	/**
-	 * Get the form action
-	 *
-	 * @return string
-	 */
-	public function getAction()
-	{
-		return $this->formRuntime->getFormDefinition()->getAction();
-	}
+    /**
+     * Get the form action
+     *
+     * @return string
+     */
+    public function getAction()
+    {
+        return $this->formRuntime->getFormDefinition()->getAction();
+    }
 
-	/**
-	 * Create a field context for the given path
-	 *
-	 * @param string $path
-	 * @return FieldContext
-	 */
-	public function field($path)
-	{
-		$pathParts = explode('.', $path);
+    /**
+     * Create a field context for the given path
+     *
+     * @param string $path
+     * @return FieldContext
+     */
+    public function field($path)
+    {
+        $pathParts = explode('.', $path);
         $name = array_shift($pathParts);
 
-		$this->requestedFieldNames[] = $path;
+        $this->requestedFieldNames[] = $path;
 
-		return $this->fieldContextFactory->createFieldContext($this->formRuntime, $name, implode('.', $pathParts));
-	}
+        return $this->fieldContextFactory->createFieldContext($this->formRuntime, $name, implode('.', $pathParts));
+    }
 
-	/**
-	 * Create a page context for the given page name
-	 *
-	 * @param string $pageName
-	 * @return PageContext
-	 */
-	public function page($pageName)
-	{
-		return $this->pageContextFactory->createPageContext($this->formRuntime, $pageName);
-	}
+    /**
+     * Create a page context for the given page name
+     *
+     * @param string $pageName
+     * @return PageContext
+     */
+    public function page($pageName)
+    {
+        return $this->pageContextFactory->createPageContext($this->formRuntime, $pageName);
+    }
 
-	/**
-	 * Get an array of all field names that have been read from user side
-	 *
-	 * @return array<string>
-	 */
-	public function getRequestedFieldNames()
-	{
-		return $this->requestedFieldNames;
-	}
+    /**
+     * Get an array of all field names that have been read from user side
+     *
+     * @return array<string>
+     */
+    public function getRequestedFieldNames()
+    {
+        return $this->requestedFieldNames;
+    }
 
-	/**
+    /**
      * @param string $methodName
      * @return boolean
      */
     public function allowsCallOfMethod($methodName)
     {
-		return true;
+        return true;
     }
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/PageContext.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Context/PageContext.php
@@ -20,15 +20,15 @@ use PackageFactory\AtomicFusion\Forms\Domain\Service\Runtime\FormRuntimeInterfac
  */
 class PageContext implements ProtectedContextAwareInterface
 {
-	/**
-	 * @var FormRuntimeInterface
-	 */
-	protected $formRuntime;
+    /**
+     * @var FormRuntimeInterface
+     */
+    protected $formRuntime;
 
-	/**
-	 * @var string
-	 */
-	protected $pageName;
+    /**
+     * @var string
+     */
+    protected $pageName;
 
     /**
      * @Flow\Inject
@@ -36,51 +36,51 @@ class PageContext implements ProtectedContextAwareInterface
      */
     protected $fieldContextFactory;
 
-	/**
-	 * Constructor
-	 *
-	 * @param FormRuntimeInterface $formRuntime
-	 * @param string $pageName
-	 */
-	public function __construct(FormRuntimeInterface $formRuntime, $pageName)
-	{
-		$this->formRuntime = $formRuntime;
-		$this->pageName = $pageName;
-	}
+    /**
+     * Constructor
+     *
+     * @param FormRuntimeInterface $formRuntime
+     * @param string $pageName
+     */
+    public function __construct(FormRuntimeInterface $formRuntime, $pageName)
+    {
+        $this->formRuntime = $formRuntime;
+        $this->pageName = $pageName;
+    }
 
-	/**
-	 * Get the page label
-	 *
-	 * @return string
-	 */
-	public function getLabel()
-	{
-		return $this->formRuntime->getFormDefinition()->getPageDefinition($this->pageName)->getLabel();
-	}
+    /**
+     * Get the page label
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->formRuntime->getFormDefinition()->getPageDefinition($this->pageName)->getLabel();
+    }
 
-	/**
-	 * Get the page name
-	 *
-	 * @return string
-	 */
-	public function getName()
-	{
-		return $this->formRuntime->getFormDefinition()->getPageDefinition($this->pageName)->getName();
-	}
+    /**
+     * Get the page name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->formRuntime->getFormDefinition()->getPageDefinition($this->pageName)->getName();
+    }
 
-	/**
-	 * Create a field context for the given path
-	 *
-	 * @param string $path
-	 * @return FieldContext
-	 */
-	public function field($path)
-	{
+    /**
+     * Create a field context for the given path
+     *
+     * @param string $path
+     * @return FieldContext
+     */
+    public function field($path)
+    {
         $pathParts = explode('.', $path);
         $name = array_shift($pathParts);
 
-		return $this->fieldContextFactory->createFieldContext($this->formRuntime, $name, implode('.', $pathParts));
-	}
+        return $this->fieldContextFactory->createFieldContext($this->formRuntime, $name, implode('.', $pathParts));
+    }
 
     /**
      * Check if this represents the current page
@@ -92,12 +92,12 @@ class PageContext implements ProtectedContextAwareInterface
         return $this->formRuntime->getFormState()->isCurrentPage($this->pageName);
     }
 
-	/**
+    /**
      * @param string $methodName
      * @return boolean
      */
     public function allowsCallOfMethod($methodName)
     {
-		return true;
+        return true;
     }
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Model/Definition/FormDefinitionInterface.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Model/Definition/FormDefinitionInterface.php
@@ -127,5 +127,4 @@ interface FormDefinitionInterface
      * @return boolean
      */
     public function hasPages();
-
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Model/Finisher/LogFinisher.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Model/Finisher/LogFinisher.php
@@ -32,10 +32,10 @@ class LogFinisher implements FinisherInterface
     protected $severity = 'INFO';
 
     /**
-	 * @Flow\Inject
-	 * @var SystemLoggerInterface
-	 */
-	protected $logger;
+     * @Flow\Inject
+     * @var SystemLoggerInterface
+     */
+    protected $logger;
 
     /**
      * Set the message

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Model/Processor/DefaultProcessor.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Model/Processor/DefaultProcessor.php
@@ -31,14 +31,14 @@ class DefaultProcessor implements ProcessorInterface
     /**
      * @inheritdoc
      */
-     public function apply(
-         PropertyMappingConfiguration $propertyMappingConfiguration,
-         Result $result,
-         FieldDefinitionInterface $fieldDefinition,
-         array $options,
-         $input
-    )
-    {
+    public function apply(
+        PropertyMappingConfiguration $propertyMappingConfiguration,
+        Result $result,
+        FieldDefinitionInterface $fieldDefinition,
+        array $options,
+        $input
+    ) {
+    
         if ($type = $fieldDefinition->getType()) {
             $propertyMapper = $this->propertyMapperFactory->createPropertyMapper();
             $value = $propertyMapper->convert($input, $type, $propertyMappingConfiguration);
@@ -53,15 +53,15 @@ class DefaultProcessor implements ProcessorInterface
      * @inheritdoc
      * @codeCoverageIgnore
      */
-     public function rollback(
-         PropertyMappingConfiguration $propertyMappingConfiguration,
-         Result $result,
-         FieldDefinitionInterface $fieldDefinition,
-         array $options,
-         $input,
-         $value
-    )
-    {
+    public function rollback(
+        PropertyMappingConfiguration $propertyMappingConfiguration,
+        Result $result,
+        FieldDefinitionInterface $fieldDefinition,
+        array $options,
+        $input,
+        $value
+    ) {
+    
         //
         // Nothing to do here
         //

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/Runtime/FormRuntime.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/Runtime/FormRuntime.php
@@ -27,10 +27,10 @@ use PackageFactory\AtomicFusion\Forms\Factory\PropertyMappingConfigurationFactor
  */
 class FormRuntime implements FormRuntimeInterface
 {
-	/**
-	 * @var ActionRequest
-	 */
-	protected $request;
+    /**
+     * @var ActionRequest
+     */
+    protected $request;
 
     /**
      * @var FormStateInterface
@@ -42,43 +42,43 @@ class FormRuntime implements FormRuntimeInterface
      */
     protected $formDefinition;
 
-	/**
-	 * @Flow\Inject
-	 * @var Task\ProcessTaskInterface
-	 */
-	protected $processTask;
+    /**
+     * @Flow\Inject
+     * @var Task\ProcessTaskInterface
+     */
+    protected $processTask;
 
-	/**
-	 * @Flow\Inject
-	 * @var Task\ValidateTaskInterface
-	 */
-	protected $validateTask;
+    /**
+     * @Flow\Inject
+     * @var Task\ValidateTaskInterface
+     */
+    protected $validateTask;
 
-	/**
-	 * @Flow\Inject
-	 * @var Task\RollbackTaskInterface
-	 */
-	protected $rollbackTask;
+    /**
+     * @Flow\Inject
+     * @var Task\RollbackTaskInterface
+     */
+    protected $rollbackTask;
 
-	/**
-	 * @Flow\Inject
-	 * @var Task\FinishTaskInterface
-	 */
-	protected $finishTask;
+    /**
+     * @Flow\Inject
+     * @var Task\FinishTaskInterface
+     */
+    protected $finishTask;
 
-	/**
+    /**
      * @var PropertyMappingConfiguration
      */
     protected $propertyMappingConfiguration;
 
-	/**
-	 * @Flow\Inject
+    /**
+     * @Flow\Inject
      * @var PropertyMappingConfigurationFactory
      */
     protected $propertyMappingConfigurationFactory;
 
-	/**
-	 * @Flow\Inject
+    /**
+     * @Flow\Inject
      * @var FormStateFactory
      */
     protected $formStateFactory;
@@ -94,9 +94,9 @@ class FormRuntime implements FormRuntimeInterface
         $this->formDefinition = $formDefinition;
 
         //
-		// Create sub request
-		//
-		$rootRequest = $request->getMainRequest() ?: $request;
+        // Create sub request
+        //
+        $rootRequest = $request->getMainRequest() ?: $request;
         $pluginArguments = $rootRequest->getPluginArguments();
 
         $this->request = new ActionRequest($request);
@@ -108,20 +108,20 @@ class FormRuntime implements FormRuntimeInterface
     }
 
     /**
-	 * Restore or initialize form state, create property mapping configuration
-	 *
-	 * @return void
-	 */
-	protected function initializeObject()
-	{
-		$this->formState = $this->formStateFactory->createFromActionRequest($this->request);
-		$this->formState->mergeArguments($this->request->getArguments());
+     * Restore or initialize form state, create property mapping configuration
+     *
+     * @return void
+     */
+    protected function initializeObject()
+    {
+        $this->formState = $this->formStateFactory->createFromActionRequest($this->request);
+        $this->formState->mergeArguments($this->request->getArguments());
 
         $this->propertyMappingConfiguration = $this->propertyMappingConfigurationFactory
-			->createTrustedPropertyMappingConfiguration(
-				$this->request->getInternalArgument('__trustedProperties')
-			);
-	}
+            ->createTrustedPropertyMappingConfiguration(
+                $this->request->getInternalArgument('__trustedProperties')
+            );
+    }
 
     /**
      * @inheritdoc
@@ -147,13 +147,13 @@ class FormRuntime implements FormRuntimeInterface
         return $this->formState;
     }
 
-	/**
+    /**
      * @inheritdoc
      */
-	public function shouldProcess()
-	{
-		return !$this->formState->isInitialCall();
-	}
+    public function shouldProcess()
+    {
+        return !$this->formState->isInitialCall();
+    }
 
     /**
      * @inheritdoc
@@ -166,24 +166,24 @@ class FormRuntime implements FormRuntimeInterface
         foreach ($fieldDefinitions as $fieldDefinition) {
             $argument = $this->formState->getArgument($fieldDefinition->getName());
 
-			$value = $this->processTask->run(
-				$this->propertyMappingConfiguration,
-				$fieldDefinition,
-				$argument,
-				$this->formState->getValidationResult()
-			);
+            $value = $this->processTask->run(
+                $this->propertyMappingConfiguration,
+                $fieldDefinition,
+                $argument,
+                $this->formState->getValidationResult()
+            );
 
-			$this->formState->addValue($fieldDefinition->getName(), $value);
+            $this->formState->addValue($fieldDefinition->getName(), $value);
         }
     }
 
-	/**
+    /**
      * @inheritdoc
      */
-	public function shouldValidate()
-	{
-		return !$this->formState->isInitialCall() && count($this->formState->getValues()) > 0;
-	}
+    public function shouldValidate()
+    {
+        return !$this->formState->isInitialCall() && count($this->formState->getValues()) > 0;
+    }
 
     /**
      * @inheritdoc
@@ -194,61 +194,61 @@ class FormRuntime implements FormRuntimeInterface
 
         foreach ($fieldDefinitions as $fieldDefinition) {
             $value = $this->formState->getValue($fieldDefinition->getName());
-			$this->validateTask->run($fieldDefinition, $value, $this->formState->getValidationResult());
+            $this->validateTask->run($fieldDefinition, $value, $this->formState->getValidationResult());
         }
     }
 
-	/**
+    /**
      * @inheritdoc
      */
-	public function shouldRollback()
-	{
-		return $this->formState->getValidationResult()->hasErrors();
-	}
+    public function shouldRollback()
+    {
+        return $this->formState->getValidationResult()->hasErrors();
+    }
 
     /**
      * @inheritdoc
      */
     public function rollback()
     {
-		$fieldDefinitions = $this->getFieldDefinitionsForCurrentPage();
+        $fieldDefinitions = $this->getFieldDefinitionsForCurrentPage();
 
         foreach ($fieldDefinitions as $fieldDefinition) {
-			$argument = $this->formState->getArgument($fieldDefinition->getName());
-			$value = $this->formState->getValue($fieldDefinition->getName());
+            $argument = $this->formState->getArgument($fieldDefinition->getName());
+            $value = $this->formState->getValue($fieldDefinition->getName());
 
-			$restoredValue = $this->rollbackTask
-				->run(
-					$this->propertyMappingConfiguration,
-					$fieldDefinition,
-					$argument,
-					$value,
-					$this->formState->getValidationResult()
-				);
+            $restoredValue = $this->rollbackTask
+                ->run(
+                    $this->propertyMappingConfiguration,
+                    $fieldDefinition,
+                    $argument,
+                    $value,
+                    $this->formState->getValidationResult()
+                );
 
-			$this->formState->addValue($fieldDefinition->getName(), $restoredValue);
+            $this->formState->addValue($fieldDefinition->getName(), $restoredValue);
         }
     }
 
-	/**
+    /**
      * @inheritdoc
      */
-	public function shouldFinish()
-	{
-		$pageDefinitions = $this->formDefinition->getPageDefinitions();
-		$isOnLastPage = false;
+    public function shouldFinish()
+    {
+        $pageDefinitions = $this->formDefinition->getPageDefinitions();
+        $isOnLastPage = false;
 
-		if (is_array($pageDefinitions)) {
-			$lastPageDefinition = array_pop($pageDefinitions);
-			if ($lastPageDefinition) {
-				$isOnLastPage = $this->formState->getCurrentPage() === $lastPageDefinition->getName();
-			}
-		}
+        if (is_array($pageDefinitions)) {
+            $lastPageDefinition = array_pop($pageDefinitions);
+            if ($lastPageDefinition) {
+                $isOnLastPage = $this->formState->getCurrentPage() === $lastPageDefinition->getName();
+            }
+        }
 
-		return !$this->formState->isInitialCall() && !$this->formState->getValidationResult()->hasErrors() && (
-			!$this->formDefinition->hasPages() || $isOnLastPage
-		);
-	}
+        return !$this->formState->isInitialCall() && !$this->formState->getValidationResult()->hasErrors() && (
+            !$this->formDefinition->hasPages() || $isOnLastPage
+        );
+    }
 
     /**
      * @inheritdoc
@@ -273,6 +273,6 @@ class FormRuntime implements FormRuntimeInterface
                 ->getFieldDefinitions();
         }
 
-		return $this->formDefinition->getFieldDefinitions();
+        return $this->formDefinition->getFieldDefinitions();
     }
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/Runtime/Task/ProcessTask.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/Runtime/Task/ProcessTask.php
@@ -38,8 +38,8 @@ class ProcessTask implements ProcessTaskInterface
         FieldDefinitionInterface $fieldDefinition,
         $input,
         Result $validationResult
-    )
-    {
+    ) {
+    
         $processor = $this->processorResolver->resolve($fieldDefinition->getProcessorDefinition());
 
         return $processor->apply(

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/Runtime/Task/RollbackTask.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/Runtime/Task/RollbackTask.php
@@ -16,6 +16,7 @@ use Neos\Error\Messages\Result;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use PackageFactory\AtomicFusion\Forms\Domain\Model\Definition\FieldDefinitionInterface;
 use PackageFactory\AtomicFusion\Forms\Domain\Service\Resolver\ProcessorResolverInterface;
+
 /**
  * Rollback side effects if something went wrong during processing or validation
  *
@@ -38,8 +39,8 @@ class RollbackTask implements RollbackTaskInterface
         $input,
         $value,
         Result $validationResult
-    )
-    {
+    ) {
+    
         $processor = $this->processorResolver->resolve($fieldDefinition->getProcessorDefinition());
 
         $processor->rollback(

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/Runtime/Task/ValidateTask.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/Runtime/Task/ValidateTask.php
@@ -31,10 +31,10 @@ class ValidateTask implements ValidateTaskInterface
     protected $validatorResolver;
 
     /**
-	 * @Flow\Inject
-	 * @var MessageFactory
-	 */
-	protected $messageFactory;
+     * @Flow\Inject
+     * @var MessageFactory
+     */
+    protected $messageFactory;
 
     /**
      * @inheritdoc

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/State/Factory/FormStateFactory.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/State/Factory/FormStateFactory.php
@@ -49,8 +49,8 @@ class FormStateFactory
     public function createFromActionRequest(ActionRequest $request)
     {
         if ($serializedFormState = $request->getInternalArgument('__state')) {
-			return $this->cryptographyService->decodeHiddenFormMetadata($serializedFormState);
-		}
+            return $this->cryptographyService->decodeHiddenFormMetadata($serializedFormState);
+        }
 
         return $this->createFormState();
     }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/State/FormState.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/State/FormState.php
@@ -21,88 +21,88 @@ use Neos\Error\Messages\Result;
  */
 class FormState implements FormStateInterface
 {
-	/**
-	 * @var boolean
-	 */
-	protected $__isInitialCall = true;
+    /**
+     * @var boolean
+     */
+    protected $__isInitialCall = true;
 
     /**
-	 * @var array
-	 */
-	protected $arguments = [];
+     * @var array
+     */
+    protected $arguments = [];
 
     /**
-	 * @var array
-	 */
-	protected $values = [];
+     * @var array
+     */
+    protected $values = [];
 
     /**
-	 * @var Result
-	 */
-	protected $validationResult;
+     * @var Result
+     */
+    protected $validationResult;
 
-	/**
-	 * @var string
-	 */
-	protected $currentPage = null;
+    /**
+     * @var string
+     */
+    protected $currentPage = null;
 
-	/**
-	 * Constructor
-	 */
-	public function __construct()
-	{
-		$this->validationResult = new Result();
-	}
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->validationResult = new Result();
+    }
 
     /**
      * @inheritdoc
      */
-	public function setArguments(array $arguments)
-	{
-		$this->arguments = $arguments;
-	}
+    public function setArguments(array $arguments)
+    {
+        $this->arguments = $arguments;
+    }
 
     /**
      * @inheritdoc
      */
     public function addArgument($name, $value)
     {
-		$this->arguments[$name] = $value;
+        $this->arguments[$name] = $value;
     }
-
-	/**
-     * @inheritdoc
-     */
-	public function mergeArguments(array $arguments)
-	{
-		$this->arguments = Arrays::arrayMergeRecursiveOverrule(
-			$this->arguments,
-			$arguments
-		);
-	}
 
     /**
      * @inheritdoc
      */
-	public function getArguments()
-	{
-		return $this->arguments;
-	}
+    public function mergeArguments(array $arguments)
+    {
+        $this->arguments = Arrays::arrayMergeRecursiveOverrule(
+            $this->arguments,
+            $arguments
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
 
     /**
      * @inheritdoc
      */
     public function getArgument($path)
-	{
-		return ObjectAccess::getPropertyPath($this->arguments, $path);
-	}
+    {
+        return ObjectAccess::getPropertyPath($this->arguments, $path);
+    }
 
     /**
      * @inheritdoc
      */
     public function setValues(array $values)
     {
-		$this->values = $values;
+        $this->values = $values;
     }
 
     /**
@@ -110,7 +110,7 @@ class FormState implements FormStateInterface
      */
     public function addValue($name, $value)
     {
-		$this->values[$name] = $value;
+        $this->values[$name] = $value;
     }
 
     /**
@@ -118,24 +118,24 @@ class FormState implements FormStateInterface
      */
     public function getValues()
     {
-		return $this->values;
+        return $this->values;
     }
 
     /**
      * @inheritdoc
      */
     public function getValue($path)
-	{
-		return ObjectAccess::getPropertyPath($this->values, $path);
-	}
+    {
+        return ObjectAccess::getPropertyPath($this->values, $path);
+    }
 
     /**
      * @inheritdoc
      */
-	public function setCurrentPage($pageIdentifier)
-	{
-		$this->currentPage = $pageIdentifier;
-	}
+    public function setCurrentPage($pageIdentifier)
+    {
+        $this->currentPage = $pageIdentifier;
+    }
 
     /**
      * @inheritdoc
@@ -148,48 +148,48 @@ class FormState implements FormStateInterface
     /**
      * @inheritdoc
      */
-	public function getCurrentPage()
-	{
-		return $this->currentPage;
-	}
+    public function getCurrentPage()
+    {
+        return $this->currentPage;
+    }
 
     /**
      * @inheritdoc
      */
-	public function isCurrentPage($pageIdentifier)
-	{
-		return $this->currentPage === $pageIdentifier;
-	}
+    public function isCurrentPage($pageIdentifier)
+    {
+        return $this->currentPage === $pageIdentifier;
+    }
 
     /**
      * @inheritdoc
      */
-	public function isInitialCall()
-	{
-		return $this->__isInitialCall;
-	}
+    public function isInitialCall()
+    {
+        return $this->__isInitialCall;
+    }
 
-	/**
-	 * Indicate, that the form has already been called when this object gets
-	 * unserialized
-	 *
-	 * Re-Initialize state parts that weren't persisted
-	 *
-	 * @return void
-	 */
-	public function __wakeup()
-	{
-		$this->__isInitialCall = false;
+    /**
+     * Indicate, that the form has already been called when this object gets
+     * unserialized
+     *
+     * Re-Initialize state parts that weren't persisted
+     *
+     * @return void
+     */
+    public function __wakeup()
+    {
+        $this->__isInitialCall = false;
         $this->validationResult = new Result();
-	}
+    }
 
-	/**
-	 * Invalidate state parts that should not be persisted between pages
-	 *
-	 * @return void
-	 */
-	public function __sleep()
-	{
+    /**
+     * Invalidate state parts that should not be persisted between pages
+     *
+     * @return void
+     */
+    public function __sleep()
+    {
         return ['arguments', 'values', 'currentPage'];
-	}
+    }
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/State/FormState.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/State/FormState.php
@@ -24,7 +24,7 @@ class FormState implements FormStateInterface
     /**
      * @var boolean
      */
-    protected $__isInitialCall = true;
+    protected $initialCall = true;
 
     /**
      * @var array
@@ -166,7 +166,7 @@ class FormState implements FormStateInterface
      */
     public function isInitialCall()
     {
-        return $this->__isInitialCall;
+        return $this->initialCall;
     }
 
     /**
@@ -179,7 +179,7 @@ class FormState implements FormStateInterface
      */
     public function __wakeup()
     {
-        $this->__isInitialCall = false;
+        $this->initialCall = false;
         $this->validationResult = new Result();
     }
 

--- a/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/State/FormStateInterface.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Domain/Service/State/FormStateInterface.php
@@ -25,7 +25,7 @@ interface FormStateInterface
      * @param array $arguments
      * @return void
      */
-	public function setArguments(array $arguments);
+    public function setArguments(array $arguments);
 
     /**
      * Add an argument
@@ -49,7 +49,7 @@ interface FormStateInterface
      *
      * @return array
      */
-	public function getArguments();
+    public function getArguments();
 
     /**
      * Get an argument by path
@@ -104,14 +104,14 @@ interface FormStateInterface
      * @param string $pageIdentifier
      * @return void
      */
-	public function setCurrentPage($pageIdentifier);
+    public function setCurrentPage($pageIdentifier);
 
     /**
      * Get the current page
      *
      * @return string
      */
-	public function getCurrentPage();
+    public function getCurrentPage();
 
     /**
      * Check if the given page is the current page
@@ -119,12 +119,12 @@ interface FormStateInterface
      * @param string  $pageIdentifier
      * @return boolean
      */
-	public function isCurrentPage($pageIdentifier);
+    public function isCurrentPage($pageIdentifier);
 
-	/**
-	 * Determine whether the form is initially called
-	 *
-	 * @return boolean
-	 */
-	public function isInitialCall();
+    /**
+     * Determine whether the form is initially called
+     *
+     * @return boolean
+     */
+    public function isInitialCall();
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Fusion/Fields/FieldCollectionImplementation.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Fusion/Fields/FieldCollectionImplementation.php
@@ -50,9 +50,7 @@ class FieldCollectionImplementation extends AbstractFusionObject
      */
     protected function renderFieldDefinition($itemName, $item)
     {
-        $this->runtime->pushContextArray($this->runtime->getCurrentContext() + [
-            $itemName => $item
-        ]);
+        $this->runtime->pushContext($itemName, $item);
 
         $fieldDefinition = $this->runtime->evaluate(sprintf('%s/fieldRenderer', $this->path), $this);
 

--- a/Classes/PackageFactory/AtomicFusion/Forms/Fusion/Finishers/FinisherCollectionImplementation.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Fusion/Finishers/FinisherCollectionImplementation.php
@@ -49,9 +49,7 @@ class FinisherCollectionImplementation extends AbstractFusionObject
      */
     protected function renderFinisherDefinition($itemName, $item)
     {
-        $this->runtime->pushContextArray($this->runtime->getCurrentContext() + [
-            $itemName => $item
-        ]);
+        $this->runtime->pushContext($itemName, $item);
 
         $finisherDefinition = $this->runtime->evaluate(sprintf('%s/finisherRenderer', $this->path), $this);
 

--- a/Classes/PackageFactory/AtomicFusion/Forms/Fusion/FormImplementation.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Fusion/FormImplementation.php
@@ -28,234 +28,234 @@ use PackageFactory\AtomicFusion\Forms\Service\PropertyMappingConfigurationServic
 
 class FormImplementation extends AbstractFusionObject
 {
-	/**
-	 * @Flow\Inject
-	 * @var CryptographyService
-	 */
-	protected $cryptographyService;
+    /**
+     * @Flow\Inject
+     * @var CryptographyService
+     */
+    protected $cryptographyService;
 
-	/**
-	 * @Flow\Inject
-	 * @var FormAugmentationService
-	 */
-	protected $formAugmentationService;
+    /**
+     * @Flow\Inject
+     * @var FormAugmentationService
+     */
+    protected $formAugmentationService;
 
-	/**
-	 * @Flow\Inject
-	 * @var HiddenInputTagMappingService
-	 */
-	protected $hiddenInputTagMappingService;
+    /**
+     * @Flow\Inject
+     * @var HiddenInputTagMappingService
+     */
+    protected $hiddenInputTagMappingService;
 
-	/**
-	 * @Flow\Inject
-	 * @var PropertyMappingConfigurationService
-	 */
-	protected $propertyMappingConfigurationService;
+    /**
+     * @Flow\Inject
+     * @var PropertyMappingConfigurationService
+     */
+    protected $propertyMappingConfigurationService;
 
-	/**
-	 * @Flow\Inject
-	 * @var FormDefinitionFactory
-	 */
-	protected $formDefinitionFactory;
+    /**
+     * @Flow\Inject
+     * @var FormDefinitionFactory
+     */
+    protected $formDefinitionFactory;
 
-	/**
-	 * @Flow\Inject
-	 * @var FormRuntimeFactory
-	 */
-	protected $formRuntimeFactory;
+    /**
+     * @Flow\Inject
+     * @var FormRuntimeFactory
+     */
+    protected $formRuntimeFactory;
 
-	/**
-	 * @Flow\Inject
-	 * @var FormContextFactory
-	 */
-	protected $formContextFactory;
+    /**
+     * @Flow\Inject
+     * @var FormContextFactory
+     */
+    protected $formContextFactory;
 
-	/**
-	 * @var FormDefinitionInterface
-	 */
-	protected $formDefinition;
+    /**
+     * @var FormDefinitionInterface
+     */
+    protected $formDefinition;
 
-	/**
-	 * @var FormRuntimeInterface
-	 */
-	protected $formRuntime;
+    /**
+     * @var FormRuntimeInterface
+     */
+    protected $formRuntime;
 
-	/**
-	 * Create a form definition from the current fusion configuration
-	 *
-	 * @return FormDefinitionInterface
-	 */
-	public function getFormDefinition()
-	{
-		if ($this->formDefinition) {
-			return $this->formDefinition;
-		}
+    /**
+     * Create a form definition from the current fusion configuration
+     *
+     * @return FormDefinitionInterface
+     */
+    public function getFormDefinition()
+    {
+        if ($this->formDefinition) {
+            return $this->formDefinition;
+        }
 
-		$fields = $this->tsValue('fields');
-		$finishers = $this->tsValue('finishers');
-		$pages = $this->tsValue('pages');
+        $fields = $this->tsValue('fields');
+        $finishers = $this->tsValue('finishers');
+        $pages = $this->tsValue('pages');
 
-		$formDefinition = $this->formDefinitionFactory->createFormDefinition([
-			'label' => $this->tsValue('label'),
-			'name' => $this->tsValue('name'),
-			'action' => $this->tsValue('action')
-		]);
+        $formDefinition = $this->formDefinitionFactory->createFormDefinition([
+            'label' => $this->tsValue('label'),
+            'name' => $this->tsValue('name'),
+            'action' => $this->tsValue('action')
+        ]);
 
-		foreach ($fields as $field) {
-			$field->setFormDefinition($formDefinition);
-			$formDefinition->addFieldDefinition($field);
-		}
+        foreach ($fields as $field) {
+            $field->setFormDefinition($formDefinition);
+            $formDefinition->addFieldDefinition($field);
+        }
 
-		foreach ($finishers as $finisher) {
-			$formDefinition->addFinisherDefinition($finisher);
-		}
+        foreach ($finishers as $finisher) {
+            $formDefinition->addFinisherDefinition($finisher);
+        }
 
-		foreach ($pages as $page) {
-			$page->setFormDefinition($formDefinition);
-			$formDefinition->addPageDefinition($page);
-		}
+        foreach ($pages as $page) {
+            $page->setFormDefinition($formDefinition);
+            $formDefinition->addPageDefinition($page);
+        }
 
-		return $this->formDefinition = $formDefinition;
-	}
+        return $this->formDefinition = $formDefinition;
+    }
 
-	/**
-	 * Create a new form runtime from the current fusion configuration and the current
-	 * action request
-	 *
-	 * @return FormRuntimeInterface
-	 */
-	public function getFormRuntime()
-	{
-		if ($this->formRuntime) {
-			return $this->formRuntime;
-		}
+    /**
+     * Create a new form runtime from the current fusion configuration and the current
+     * action request
+     *
+     * @return FormRuntimeInterface
+     */
+    public function getFormRuntime()
+    {
+        if ($this->formRuntime) {
+            return $this->formRuntime;
+        }
 
-		$formDefinition = $this->getFormDefinition();
-		$request = $this->runtime->getControllerContext()->getRequest();
+        $formDefinition = $this->getFormDefinition();
+        $request = $this->runtime->getControllerContext()->getRequest();
 
-		return $this->formRuntime = $this->formRuntimeFactory->createFormRuntime($formDefinition, $request);
-	}
+        return $this->formRuntime = $this->formRuntimeFactory->createFormRuntime($formDefinition, $request);
+    }
 
-	public function evaluate()
-	{
-		//
-		// Create form definition
-		//
-		$formRuntime = $this->getFormRuntime();
-		$formContext = $this->formContextFactory->createFormContext($formRuntime);
+    public function evaluate()
+    {
+        //
+        // Create form definition
+        //
+        $formRuntime = $this->getFormRuntime();
+        $formContext = $this->formContextFactory->createFormContext($formRuntime);
 
-		$this->runtime->pushContext($this->tsValue('formContext'), $formContext);
+        $this->runtime->pushContext($this->tsValue('formContext'), $formContext);
 
-		$renderedForm = $this->processForm($formRuntime);
-		$renderedForm = $renderedForm ? $renderedForm : $this->augmentForm(
-			$this->renderForm($formRuntime, $formContext),
-			$formRuntime,
-			$formContext
-		);
-		$this->runtime->popContext();
+        $renderedForm = $this->processForm($formRuntime);
+        $renderedForm = $renderedForm ? $renderedForm : $this->augmentForm(
+            $this->renderForm($formRuntime, $formContext),
+            $formRuntime,
+            $formContext
+        );
+        $this->runtime->popContext();
 
-		return $renderedForm;
-	}
+        return $renderedForm;
+    }
 
-	/**
-	 * Perform runtime tasks on current form state
-	 *
-	 * @param FormRuntimeInterface $formRuntime
-	 * @return string|null
-	 */
-	public function processForm(FormRuntimeInterface $formRuntime)
-	{
-		if ($formRuntime->shouldProcess()) {
-			$formRuntime->process();
+    /**
+     * Perform runtime tasks on current form state
+     *
+     * @param FormRuntimeInterface $formRuntime
+     * @return string|null
+     */
+    public function processForm(FormRuntimeInterface $formRuntime)
+    {
+        if ($formRuntime->shouldProcess()) {
+            $formRuntime->process();
 
-			if ($formRuntime->shouldValidate()) {
-				$formRuntime->validate();
+            if ($formRuntime->shouldValidate()) {
+                $formRuntime->validate();
 
-				if ($formRuntime->shouldRollback()) {
-					$formRuntime->rollback();
-				} else if ($formRuntime->shouldFinish()) {
-					$controllerContext = $this->runtime->getControllerContext();
-					$finisherState = $formRuntime->finish($controllerContext->getResponse());
-					$response = $finisherState->getResponse();
+                if ($formRuntime->shouldRollback()) {
+                    $formRuntime->rollback();
+                } elseif ($formRuntime->shouldFinish()) {
+                    $controllerContext = $this->runtime->getControllerContext();
+                    $finisherState = $formRuntime->finish($controllerContext->getResponse());
+                    $response = $finisherState->getResponse();
 
-					if ($statusCode = $response->getStatusCode()) {
-						$controllerContext->getResponse()->setStatus($statusCode);
-					}
+                    if ($statusCode = $response->getStatusCode()) {
+                        $controllerContext->getResponse()->setStatus($statusCode);
+                    }
 
-					if ($flashMessages = $finisherState->getFlashMessageContainer()->getMessagesAndFlush()) {
-						foreach ($flashMessages as $flashMessage) {
-							$controllerContext->getFlashMessageContainer()->addMessage($flashMessage);
-						}
-					}
+                    if ($flashMessages = $finisherState->getFlashMessageContainer()->getMessagesAndFlush()) {
+                        foreach ($flashMessages as $flashMessage) {
+                            $controllerContext->getFlashMessageContainer()->addMessage($flashMessage);
+                        }
+                    }
 
-					if ($content = $response->getContent()) {
-						return $content;
-					}
-				}
-			}
-		}
-	}
+                    if ($content = $response->getContent()) {
+                        return $content;
+                    }
+                }
+            }
+        }
+    }
 
-	/**
-	 * Render the form
-	 *
-	 * @param FormRuntimeInterface $formRuntime
-	 * @return string
-	 */
-	public function renderForm(FormRuntimeInterface $formRuntime, FormContext $formContext)
-	{
-		$formDefinition = $formRuntime->getFormDefinition();
-		$formState = $formRuntime->getFormState();
+    /**
+     * Render the form
+     *
+     * @param FormRuntimeInterface $formRuntime
+     * @return string
+     */
+    public function renderForm(FormRuntimeInterface $formRuntime, FormContext $formContext)
+    {
+        $formDefinition = $formRuntime->getFormDefinition();
+        $formState = $formRuntime->getFormState();
 
-		if ($formDefinition->hasPages()) {
-			$currentPage = $formState->getCurrentPage();
-			$nextPage = $currentPage;
+        if ($formDefinition->hasPages()) {
+            $currentPage = $formState->getCurrentPage();
+            $nextPage = $currentPage;
 
-			if (!$formState->getValidationResult()->hasErrors()) {
-				$nextPage = $formDefinition->getNextPage($currentPage);
-			}
+            if (!$formState->getValidationResult()->hasErrors()) {
+                $nextPage = $formDefinition->getNextPage($currentPage);
+            }
 
-			$formState->setCurrentPage($nextPage);
+            $formState->setCurrentPage($nextPage);
 
-			$this->runtime->pushContext($this->tsValue('pageContext'), $formContext->page($nextPage));
+            $this->runtime->pushContext($this->tsValue('pageContext'), $formContext->page($nextPage));
 
-			$renderedForm = $this->runtime->render(sprintf('%s/renderer/%s', $this->path, $nextPage));
+            $renderedForm = $this->runtime->render(sprintf('%s/renderer/%s', $this->path, $nextPage));
 
-			$this->runtime->popContext();
-		} else {
-			$renderedForm = $this->runtime->render(sprintf('%s/renderer', $this->path));
-		}
+            $this->runtime->popContext();
+        } else {
+            $renderedForm = $this->runtime->render(sprintf('%s/renderer', $this->path));
+        }
 
-		return $renderedForm;
-	}
+        return $renderedForm;
+    }
 
-	/**
-	 * Augment rendering result with form meta information:
-	 *
-	 *	- Form State
-	 *	- Trusted Properties
-	 *
-	 * @param string $renderedForm
-	 * @param FormRuntimeInterface $formRuntime
-	 * @param FormContext $formContext
-	 * @return string
-	 */
-	public function augmentForm($renderedForm, FormRuntimeInterface $formRuntime, FormContext $formContext)
-	{
-		return $this->formAugmentationService->injectStringAfterOpeningFormTag(
-			$renderedForm,
-			sprintf(
-				'<div style="display: none;">%s</div>',
-				$this->hiddenInputTagMappingService->convertFlatMapToHiddenInputTags([
-					'__state' => $this->cryptographyService->encodeHiddenFormMetadata(
-						$formRuntime->getFormState()
-					),
-					'__trustedProperties' => $this->propertyMappingConfigurationService
-						->generateTrustedPropertiesToken(
-							$formContext->getRequestedFieldNames()
-						)
-				], $formRuntime->getRequest()->getArgumentNamespace())
-			)
-		);
-	}
+    /**
+     * Augment rendering result with form meta information:
+     *
+     *  - Form State
+     *  - Trusted Properties
+     *
+     * @param string $renderedForm
+     * @param FormRuntimeInterface $formRuntime
+     * @param FormContext $formContext
+     * @return string
+     */
+    public function augmentForm($renderedForm, FormRuntimeInterface $formRuntime, FormContext $formContext)
+    {
+        return $this->formAugmentationService->injectStringAfterOpeningFormTag(
+            $renderedForm,
+            sprintf(
+                '<div style="display: none;">%s</div>',
+                $this->hiddenInputTagMappingService->convertFlatMapToHiddenInputTags([
+                    '__state' => $this->cryptographyService->encodeHiddenFormMetadata(
+                        $formRuntime->getFormState()
+                    ),
+                    '__trustedProperties' => $this->propertyMappingConfigurationService
+                        ->generateTrustedPropertiesToken(
+                            $formContext->getRequestedFieldNames()
+                        )
+                ], $formRuntime->getRequest()->getArgumentNamespace())
+            )
+        );
+    }
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Fusion/FormImplementation.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Fusion/FormImplementation.php
@@ -144,9 +144,7 @@ class FormImplementation extends AbstractFusionObject
 		$formRuntime = $this->getFormRuntime();
 		$formContext = $this->formContextFactory->createFormContext($formRuntime);
 
-		$this->runtime->pushContextArray($this->runtime->getCurrentContext() + [
-			$this->tsValue('formContext') => $formContext
-		]);
+		$this->runtime->pushContext($this->tsValue('formContext'), $formContext);
 
 		$renderedForm = $this->processForm($formRuntime);
 		$renderedForm = $renderedForm ? $renderedForm : $this->augmentForm(
@@ -219,9 +217,7 @@ class FormImplementation extends AbstractFusionObject
 
 			$formState->setCurrentPage($nextPage);
 
-			$this->runtime->pushContextArray($this->runtime->getCurrentContext() + [
-				$this->tsValue('pageContext') => $formContext->page($nextPage)
-			]);
+			$this->runtime->pushContext($this->tsValue('pageContext'), $formContext->page($nextPage));
 
 			$renderedForm = $this->runtime->render(sprintf('%s/renderer/%s', $this->path, $nextPage));
 

--- a/Classes/PackageFactory/AtomicFusion/Forms/Fusion/Pages/PageCollectionImplementation.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Fusion/Pages/PageCollectionImplementation.php
@@ -50,9 +50,7 @@ class PageCollectionImplementation extends AbstractFusionObject
      */
     protected function renderPageDefinition($itemName, $item)
     {
-        $this->runtime->pushContextArray($this->runtime->getCurrentContext() + [
-            $itemName => $item
-        ]);
+        $this->runtime->pushContext($itemName, $item);
 
         $pageDefinitionFactory = $this->runtime->evaluate(sprintf('%s/pageRenderer', $this->path), $this);
 

--- a/Classes/PackageFactory/AtomicFusion/Forms/Fusion/Validators/ValidatorCollectionImplementation.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Fusion/Validators/ValidatorCollectionImplementation.php
@@ -49,9 +49,7 @@ class ValidatorCollectionImplementation extends AbstractFusionObject
      */
     protected function renderValidatorDefinition($itemName, $item)
     {
-        $this->runtime->pushContextArray($this->runtime->getCurrentContext() + [
-            $itemName => $item
-        ]);
+        $this->runtime->pushContext($itemName, $item);
 
         $validatorDefinition = $this->runtime->evaluate(sprintf('%s/validatorRenderer', $this->path), $this);
 

--- a/Classes/PackageFactory/AtomicFusion/Forms/Service/CryptographyService.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Service/CryptographyService.php
@@ -19,21 +19,21 @@ use Neos\Flow\Security\Cryptography\HashService;
  */
 class CryptographyService
 {
-	/**
-	 * @Flow\Inject
-	 * @var HashService
-	 */
-	protected $hashService;
+    /**
+     * @Flow\Inject
+     * @var HashService
+     */
+    protected $hashService;
 
-	public function encodeHiddenFormMetadata($formMetadata)
-	{
-		$serializedFormState = base64_encode(serialize($formMetadata));
+    public function encodeHiddenFormMetadata($formMetadata)
+    {
+        $serializedFormState = base64_encode(serialize($formMetadata));
         return $this->hashService->appendHmac($serializedFormState);
-	}
+    }
 
-	public function decodeHiddenFormMetadata($encodedHiddenFormMetadata)
-	{
-		$serializedFormMetadata = $this->hashService->validateAndStripHmac($encodedHiddenFormMetadata);
-		return unserialize(base64_decode($serializedFormMetadata));
-	}
+    public function decodeHiddenFormMetadata($encodedHiddenFormMetadata)
+    {
+        $serializedFormMetadata = $this->hashService->validateAndStripHmac($encodedHiddenFormMetadata);
+        return unserialize(base64_decode($serializedFormMetadata));
+    }
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Service/FormAugmentationService.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Service/FormAugmentationService.php
@@ -18,30 +18,30 @@ use Neos\Flow\Annotations as Flow;
  */
 class FormAugmentationService
 {
-	/**
-	 * Add string information to the beginning of a form
-	 *
-	 * @param  string $formString
-	 * @param  string $toBeInjectedString
-	 * @return string
-	 */
-	public function injectStringAfterOpeningFormTag($formString, $toBeInjectedString)
-	{
-		$openingBracketPosition = -1;
-		$closingBracketPosition = -1;
+    /**
+     * Add string information to the beginning of a form
+     *
+     * @param  string $formString
+     * @param  string $toBeInjectedString
+     * @return string
+     */
+    public function injectStringAfterOpeningFormTag($formString, $toBeInjectedString)
+    {
+        $openingBracketPosition = -1;
+        $closingBracketPosition = -1;
 
-		while (($nextOpeningBracketPosition = strpos($formString, '<', $openingBracketPosition + 1)) !== false) {
-			if (strtolower(substr($formString, $nextOpeningBracketPosition, 5)) === '<form') {
-				$closingBracketPosition = strpos($formString, '>', $nextOpeningBracketPosition);
-				break;
-			}
+        while (($nextOpeningBracketPosition = strpos($formString, '<', $openingBracketPosition + 1)) !== false) {
+            if (strtolower(substr($formString, $nextOpeningBracketPosition, 5)) === '<form') {
+                $closingBracketPosition = strpos($formString, '>', $nextOpeningBracketPosition);
+                break;
+            }
 
-			$openingBracketPosition = $nextOpeningBracketPosition;
-		}
+            $openingBracketPosition = $nextOpeningBracketPosition;
+        }
 
-		$preInjectionString = substr($formString, 0, $closingBracketPosition + 1);
-		$postInjectionString = substr($formString, $closingBracketPosition + 1);
+        $preInjectionString = substr($formString, 0, $closingBracketPosition + 1);
+        $postInjectionString = substr($formString, $closingBracketPosition + 1);
 
-		return $preInjectionString . $toBeInjectedString . $postInjectionString;
-	}
+        return $preInjectionString . $toBeInjectedString . $postInjectionString;
+    }
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Service/HiddenInputTagMappingService.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Service/HiddenInputTagMappingService.php
@@ -18,28 +18,28 @@ use Neos\Flow\Annotations as Flow;
  */
 class HiddenInputTagMappingService
 {
-	/**
-	 * Converts flat associative arrays to a string containing hidden input fields
-	 *
-	 * @param array  $map
-	 * @param string $fieldNamePrefix [description]
-	 * @return string
-	 */
-	public function convertFlatMapToHiddenInputTags(array $map, $fieldNamePrefix)
-	{
-		$result = '';
-		foreach ($map as $key => $value) {
-			if (is_array($value) || (is_object($value) && !method_exists($value, 'toString'))) {
-				throw new \Exception('The given map needs to be flat.', 1475408307);
-			}
+    /**
+     * Converts flat associative arrays to a string containing hidden input fields
+     *
+     * @param array  $map
+     * @param string $fieldNamePrefix [description]
+     * @return string
+     */
+    public function convertFlatMapToHiddenInputTags(array $map, $fieldNamePrefix)
+    {
+        $result = '';
+        foreach ($map as $key => $value) {
+            if (is_array($value) || (is_object($value) && !method_exists($value, 'toString'))) {
+                throw new \Exception('The given map needs to be flat.', 1475408307);
+            }
 
-			$result .= sprintf(
-				'<input type="hidden" name="%s" value="%s" />',
-				sprintf('%s[%s]', $fieldNamePrefix, $key),
-				htmlspecialchars($value)
-			);
-		}
+            $result .= sprintf(
+                '<input type="hidden" name="%s" value="%s" />',
+                sprintf('%s[%s]', $fieldNamePrefix, $key),
+                htmlspecialchars($value)
+            );
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 }

--- a/Classes/PackageFactory/AtomicFusion/Forms/Service/PropertyMappingConfigurationService.php
+++ b/Classes/PackageFactory/AtomicFusion/Forms/Service/PropertyMappingConfigurationService.php
@@ -11,45 +11,45 @@ use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
  */
 class PropertyMappingConfigurationService
 {
-	/**
-	 * @Flow\Inject
-	 * @var CryptographyService
-	 */
-	protected $cryptographyService;
+    /**
+     * @Flow\Inject
+     * @var CryptographyService
+     */
+    protected $cryptographyService;
 
-	public function generateTrustedPropertiesToken(array $propertyNames)
-	{
-		return $this->cryptographyService->encodeHiddenFormMetadata($propertyNames);
-	}
+    public function generateTrustedPropertiesToken(array $propertyNames)
+    {
+        return $this->cryptographyService->encodeHiddenFormMetadata($propertyNames);
+    }
 
-	public function applyTrustedPropertiesConfiguration(
-		$trustedPropertyToken,
-		PropertyMappingConfigurationInterface $propertyMappingConfiguration
-	)
-	{
-		$propertyNames = $this->cryptographyService->decodeHiddenFormMetadata($trustedPropertyToken);
+    public function applyTrustedPropertiesConfiguration(
+        $trustedPropertyToken,
+        PropertyMappingConfigurationInterface $propertyMappingConfiguration
+    ) {
+    
+        $propertyNames = $this->cryptographyService->decodeHiddenFormMetadata($trustedPropertyToken);
 
-		foreach ($propertyNames as $propertyName) {
-			$parts = explode('.', $propertyName);
-			$currentPropertyMappingConfiguration = $propertyMappingConfiguration;
+        foreach ($propertyNames as $propertyName) {
+            $parts = explode('.', $propertyName);
+            $currentPropertyMappingConfiguration = $propertyMappingConfiguration;
 
-			foreach ($parts as $part) {
-				$currentPropertyMappingConfiguration->allowProperties($part);
-				$currentPropertyMappingConfiguration = $currentPropertyMappingConfiguration->forProperty($part);
+            foreach ($parts as $part) {
+                $currentPropertyMappingConfiguration->allowProperties($part);
+                $currentPropertyMappingConfiguration = $currentPropertyMappingConfiguration->forProperty($part);
 
-				$currentPropertyMappingConfiguration->setTypeConverterOption(
-					PersistentObjectConverter::class,
-					PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED,
-					true
-				);
-				$currentPropertyMappingConfiguration->setTypeConverterOption(
-					PersistentObjectConverter::class,
-					PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED,
-					true
-				);
-			}
-		}
+                $currentPropertyMappingConfiguration->setTypeConverterOption(
+                    PersistentObjectConverter::class,
+                    PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED,
+                    true
+                );
+                $currentPropertyMappingConfiguration->setTypeConverterOption(
+                    PersistentObjectConverter::class,
+                    PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED,
+                    true
+                );
+            }
+        }
 
-		return $propertyMappingConfiguration;
-	}
+        return $propertyMappingConfiguration;
+    }
 }

--- a/Tests/Unit/Fusion/Fields/FieldCollectionImplementationTest.php
+++ b/Tests/Unit/Fusion/Fields/FieldCollectionImplementationTest.php
@@ -39,10 +39,10 @@ class FieldCollectionImplementationTest extends UnitTestCase
             ));
 
         $fusionRuntime->expects($this->exactly(2))
-            ->method('pushContextArray')
+            ->method('pushContext')
             ->withConsecutive(
-                [['TheItemName' => 'Item1']],
-                [['TheItemName' => 'Item2']]
+                ['TheItemName', 'Item1'],
+                ['TheItemName', 'Item2']
             );
 
         $fusionRuntime->expects($this->exactly(2))->method('popContext');

--- a/Tests/Unit/Fusion/Finishers/FinisherCollectionImplementationTest.php
+++ b/Tests/Unit/Fusion/Finishers/FinisherCollectionImplementationTest.php
@@ -37,10 +37,10 @@ class FinisherCollectionImplementationTest extends UnitTestCase
             ));
 
         $fusionRuntime->expects($this->exactly(2))
-            ->method('pushContextArray')
+            ->method('pushContext')
             ->withConsecutive(
-                [['TheItemName' => 'Item1']],
-                [['TheItemName' => 'Item2']]
+                ['TheItemName', 'Item1'],
+                ['TheItemName', 'Item2']
             );
 
         $fusionRuntime->expects($this->exactly(2))->method('popContext');

--- a/Tests/Unit/Fusion/FormImplementationTest.php
+++ b/Tests/Unit/Fusion/FormImplementationTest.php
@@ -164,8 +164,8 @@ class FormImplementationTest extends UnitTestCase
             ->willReturn('form');
 
         $fusionRuntime->expects($this->once())
-            ->method('pushContextArray')
-            ->with($this->equalTo(['form' => $formContext]));
+            ->method('pushContext')
+            ->with('form', $formContext);
 
         $fusionRuntime->expects($this->once())
             ->method('popContext');
@@ -312,8 +312,8 @@ class FormImplementationTest extends UnitTestCase
         $fusionRuntime->method('getCurrentContext')->willReturn([]);
 
         $fusionRuntime->expects($this->once())
-            ->method('pushContextArray')
-            ->with($this->equalTo(['page' => $pageContext]));
+            ->method('pushContext')
+            ->with('page', $pageContext);
 
         $fusionRuntime->expects($this->once())
             ->method('popContext');

--- a/Tests/Unit/Fusion/Pages/PageCollectionImplementationTest.php
+++ b/Tests/Unit/Fusion/Pages/PageCollectionImplementationTest.php
@@ -39,10 +39,10 @@ class PageCollectionImplementationTest extends UnitTestCase
             ));
 
         $fusionRuntime->expects($this->exactly(2))
-            ->method('pushContextArray')
+            ->method('pushContext')
             ->withConsecutive(
-                [['TheItemName' => 'Item1']],
-                [['TheItemName' => 'Item2']]
+                ['TheItemName', 'Item1'],
+                ['TheItemName', 'Item2']
             );
 
         $fusionRuntime->expects($this->exactly(2))->method('popContext');

--- a/Tests/Unit/Fusion/Validators/ValidatorCollectionImplementationTest.php
+++ b/Tests/Unit/Fusion/Validators/ValidatorCollectionImplementationTest.php
@@ -37,10 +37,10 @@ class ValidatorCollectionImplementationTest extends UnitTestCase
             ));
 
         $fusionRuntime->expects($this->exactly(2))
-            ->method('pushContextArray')
+            ->method('pushContext')
             ->withConsecutive(
-                [['TheItemName' => 'Item1']],
-                [['TheItemName' => 'Item2']]
+                ['TheItemName', 'Item1'],
+                ['TheItemName', 'Item2']
             );
 
         $fusionRuntime->expects($this->exactly(2))->method('popContext');


### PR DESCRIPTION
The fusion context was assigned previously in a manner that pervented overwriting of existing properties. Now pushContext(key, value) is used instead of pushContextArray(getContext + [key => value])